### PR TITLE
Add auto_drain option to consume tokens during a request

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ By default, throttling data is stored in memory and is thus not shared between m
 ```js
 var express = require("express");
 var throttle = require("express-throttle");
-  
+
 var app = express();
-  
+
 // Allow 5 requests at any rate with an average rate of 5/s
 app.post("/search", throttle({ "rate": "5/s" }), function(req, res, next) {
   // ...
 });
 
-// Allow 5 requests at any rate during a fixed time window of 1 sec 
+// Allow 5 requests at any rate during a fixed time window of 1 sec
 app.post("/search", throttle({ "burst": 5, "period": "1s" }), function(req, res, next) {
   // ...
 });
@@ -46,7 +46,7 @@ Combine it with a burst capacity of 10, meaning that the client can make 10 requ
 app.post("/search", throttle({ "burst": 10, "rate": "5/s" }), function(req, res, next) {
   // ...
 });
-  
+
 // "Half" requests are supported as well (1 request every other second)
 app.post("/search", throttle({ "burst": 5, "rate": "1/2s" }), function(req, res, next) {
   // ...
@@ -69,13 +69,13 @@ app.post("/search", throttle(options), function(req, res, next) {
 The "cost" per request can also be customized, making it possible to, for example whitelist certain requests:
 ```js
 var whitelist = ["ip-1", "ip-2", ...];
-  
+
 var options = {
   "burst": 10,
   "rate": "5/s",
   "cost": function(req) {
     var ip_address = req.connection.remoteAddress;
-      
+
     if (whitelist.indexOf(ip_address) >= 0) {
       return 0;
     } else if (req.session.is_privileged_user) {
@@ -85,7 +85,7 @@ var options = {
     }
   }
 };
-  
+
 app.post("/search", throttle(options), function(req, res, next) {
   // ...
 });
@@ -142,19 +142,19 @@ ExternalStorage.prototype.get = function(key, callback) {
     callback(null, bucket);
   });
 }
-  
+
 ExternalStorage.prototype.set = function(key, bucket, lifetime, callback) {
   save(key, bucket, function(err) {
     // err should be null if no errors occurred
-    callback(err); 
+    callback(err);
   });
 }
-  
+
 var options = {
   "rate": "5/s",
   "store": new ExternalStorage()
 }
-  
+
 app.post("/search", throttle(options), function(req, res, next) {
   // ...
 });
@@ -168,7 +168,7 @@ app.post("/search", throttle(options), function(req, res, next) {
 
 where *X* and *Y* are integers and *t* is the time unit which can be any of the following: `ms, s, sec, m, min, h, hour, d, day`
 
-E.g `5/s, 180/15min, 1000/d` 
+E.g `5/s, 180/15min, 1000/d`
 
 `period`: The duration of the time window after which the entire burst quota is refilled. Must be specified according to the following format: *Y/t*, where *Y* and *t* are defined as above.
 
@@ -211,12 +211,22 @@ function(req) {
 
 `cost`: Number or function used to calculate the cost for a request with an [express request object](http://expressjs.com/en/4x/api.html#req). Defaults to 1.
 
+`auto_drain`: A boolean to control if tokens are consumed before (`true`) or during (`false`) a request. Defaults to `true`.
+
+When it is set to `false`, you need to  explicitly invoke `req.drain()` to consume tokens. The method can be invoked multiple times, but it only executed once per request. Multiple configurations will stack in `req.drain()` automatically.
+
+```js
+function(req, res, next) {
+	req.drain();
+}
+```
+
 `on_allowed`: A function called when the request is passed through with an [express request object](http://expressjs.com/en/4x/api.html#req), [express response object](http://expressjs.com/en/4x/api.html#res), `next` function and a `bucket` object. Defaults to:
 ```js
 function(req, res, next, bucket) {
 	next();
 }
-``` 
+```
 
 `on_throttled`: A function called when the request is throttled with an [express request object](http://expressjs.com/en/4x/api.html#req), [express response object](http://expressjs.com/en/4x/api.html#res), `next` function and a `bucket` object. Defaults to:
 ```js

--- a/lib/options.js
+++ b/lib/options.js
@@ -12,7 +12,7 @@ exports.parse = function parse_options(options) {
 	if (options.store_size && typeof(options.store_size) != "number") {
 		throw new Error("'store_size' needs to be a number.");
 	}
-	
+
 	options.store = options.store || new MemoryStore(options.store_size || 10000);
 
 	if (options.rate) {
@@ -41,7 +41,7 @@ exports.parse = function parse_options(options) {
 		if (typeof(options.burst) != "number") {
 			throw new Error("'burst' needs to be a number.");
 		}
-		
+
 		add_methods_fixed(options);
 	} else {
 		throw new Error("Either 'rate' or 'period' must be supplied.");
@@ -66,6 +66,14 @@ exports.parse = function parse_options(options) {
 		options.cost = function() { return 1; }
 	}
 
+	if (!options.auto_drain && typeof(options.auto_drain) == "undefined") {
+		options.auto_drain = true;
+	}
+
+	if (typeof(options.auto_drain) != "boolean") {
+		throw new Error("'auto_drain' needs to be a boolean.");
+	}
+
 	if (options.on_allowed) {
 		if (typeof(options.on_allowed) != "function") {
 			throw new Error("'on_allowed' needs to be a function.");
@@ -75,7 +83,7 @@ exports.parse = function parse_options(options) {
 			next();
 		};
 	}
-	
+
 	if (options.on_throttled) {
 		if (typeof(options.on_throttled) != "function") {
 			throw new Error("'on_throttled' needs to be a function.");
@@ -129,7 +137,7 @@ function parse_period(period) {
 	var parsed_period = period.match(PERIOD_PATTERN);
 
 	if (!parsed_period) {
-		throw new Error("invalid period (e.g d, 2m, 3h)")
+		throw new Error("invalid period (e.g d, 2m, 3h)");
 	}
 
 	var amount = parseInt(parsed_period[1], 10);
@@ -179,7 +187,7 @@ function add_methods_fixed(options) {
 		return {
 			"tokens": burst,
 			"mtime": ctime,
-			"etime": ctime + period // expiration time 
+			"etime": ctime + period // expiration time
 		};
 	}
 

--- a/lib/throttle.js
+++ b/lib/throttle.js
@@ -21,8 +21,7 @@ function Throttle(opts) {
 			bucket = bucket || opts.create_bucket(t);
 			var tokens = opts.refill_bucket(t, bucket);
 			bucket.tokens = clamp_max(bucket.tokens + tokens, opts.burst);
-			var is_allowed = drain_tokens(bucket, cost);
-			bucket.mtime = t;
+			var is_allowed = drain_tokens(bucket, cost, opts.auto_drain);
 
 			opts.store.set(key, bucket, function(err) {
 				if (err) {
@@ -35,13 +34,42 @@ function Throttle(opts) {
 					opts.on_throttled(req, res, next, bucket);
 				}
 			});
+
+			if(!req.drain) {
+				req.drain = function() { }
+			}
+
+			if (!opts.auto_drain && is_allowed) {
+				var drain = req.drain;
+				var drained = false;
+
+				req.drain = function() {
+					drain();
+
+					if(!drained) {
+						drained = true;
+
+						drain_tokens(bucket, cost, true);
+						opts.store.set(key, bucket, function(err) {
+							if (err) {
+								throw err;
+							}
+						});
+					}
+				}
+
+				next();
+			}
 		});
 	};
 }
 
-function drain_tokens(bucket, cost) {
+function drain_tokens(bucket, cost, drain) {
 	if (bucket.tokens >= cost) {
-		bucket.tokens -= cost;
+		if (drain) {
+			bucket.tokens -= cost;
+			bucket.mtime = Date.now();
+		}
 		return true;
 	} else {
 		// Not enough tokens, don't remove anything

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-throttle",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Request throttling middleware for Express",
   "main": "index.js",
   "scripts": {

--- a/test/options.unit.js
+++ b/test/options.unit.js
@@ -74,7 +74,7 @@ tap.test("invalid rate...", function(t) {
 		st.throws(wrap({ "rate": "1/0m" }));
 		st.end();
 	});
-	
+
 	t.end();
 });
 
@@ -174,6 +174,31 @@ tap.test("cost not being a number or function", function(t) {
 tap.test("default cost = 1", function(t) {
 	var cost = options.parse({ "rate": "1/s" }).cost();
 	t.equal(cost, 1);
+	t.end();
+});
+
+tap.test("valid auto_drain...", function(t) {
+	t.test("when it is true", function(st) {
+		st.doesNotThrow(wrap({ "rate": "1/s", "auto_drain": true }));
+		st.end();
+	});
+
+	t.test("when it is false", function(st) {
+		st.doesNotThrow(wrap({ "rate": "1/s", "auto_drain": false }));
+		st.end();
+	});
+
+	t.end();
+});
+
+tap.test("auto_drain not being a boolean", function(t) {
+	t.throws(wrap({ "rate": "1/s", "auto_drain": null }));
+	t.end();
+});
+
+tap.test("default auto_drain = true", function(t) {
+	var auto_drain = options.parse({ "rate": "1/s" }).auto_drain;
+	t.equal(auto_drain, true);
 	t.end();
 });
 


### PR DESCRIPTION
My goal is to consume tokens in a scenario where a throttling policy doesn't occur every time. 
For example, number of times I typed a wrong password,.

These changes make this possible by adding the `auto_drain` option. It doesn't change anything in the current implementation when it is set to `true`. If it is disabled, it will stack a pile of functions in `req.drain()` and consume tokens (based on `cost` function) only when `req.drain()` is invoked. Otherwise, tokens are not consumed.

It's always good to be the first pull request :). Any suggestion is welcome.
